### PR TITLE
Minor performance optimizations

### DIFF
--- a/CRFSharp.sln
+++ b/CRFSharp.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "corpus2tag", "corpus2tag\corpus2tag.csproj", "{13558F09-565B-488E-9DBA-C1416D4CFD78}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GenerateFeature", "GenerateFeature", "{83DFEF0D-8885-44DF-BEE8-2AE2B4095C3A}"
@@ -39,6 +41,7 @@ Global
 		{13558F09-565B-488E-9DBA-C1416D4CFD78}.Debug|x86.ActiveCfg = Debug|x86
 		{13558F09-565B-488E-9DBA-C1416D4CFD78}.Debug|x86.Build.0 = Debug|x86
 		{13558F09-565B-488E-9DBA-C1416D4CFD78}.Release|Any CPU.ActiveCfg = Release|x86
+		{13558F09-565B-488E-9DBA-C1416D4CFD78}.Release|Any CPU.Build.0 = Release|x86
 		{13558F09-565B-488E-9DBA-C1416D4CFD78}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{13558F09-565B-488E-9DBA-C1416D4CFD78}.Release|Mixed Platforms.Build.0 = Release|x86
 		{13558F09-565B-488E-9DBA-C1416D4CFD78}.Release|Win32.ActiveCfg = Release|x86
@@ -109,6 +112,7 @@ Global
 		{16C2FDF6-85D3-494E-9866-AE98C1796FE4}.Debug|x86.ActiveCfg = Debug|x86
 		{16C2FDF6-85D3-494E-9866-AE98C1796FE4}.Debug|x86.Build.0 = Debug|x86
 		{16C2FDF6-85D3-494E-9866-AE98C1796FE4}.Release|Any CPU.ActiveCfg = Release|x86
+		{16C2FDF6-85D3-494E-9866-AE98C1796FE4}.Release|Any CPU.Build.0 = Release|x86
 		{16C2FDF6-85D3-494E-9866-AE98C1796FE4}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{16C2FDF6-85D3-494E-9866-AE98C1796FE4}.Release|Mixed Platforms.Build.0 = Release|x86
 		{16C2FDF6-85D3-494E-9866-AE98C1796FE4}.Release|Win32.ActiveCfg = Release|x86

--- a/CRFSharpConsole/CRFSharpConsole.csproj.user
+++ b/CRFSharpConsole/CRFSharpConsole.csproj.user
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <StartArguments>-encode -modelfile model.dat -trainfile input.txt -template template.txt -thread 2</StartArguments>
-    <StartWorkingDirectory>C:\Users\Dmitry\OneDrive\Ru\</StartWorkingDirectory>
+    <StartArguments>-encode -modelfile model.dat -trainfile input.txt -template template.txt -thread 4</StartArguments>
+    <StartWorkingDirectory>C:\Users\Admin\Source\Repos\CRFSharp2\CRFSharpConsole\bin\Release\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <PublishUrlHistory>publish\</PublishUrlHistory>

--- a/CRFSharpConsole/CRFSharpConsole.csproj.user
+++ b/CRFSharpConsole/CRFSharpConsole.csproj.user
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <StartArguments>-decode -modelfile ".\model files\Feature_Extraction_model" -inputfile "test file.txt" -outputfile ret.txt -outputsegfile ret_seg.txt -nbest 1</StartArguments>
-    <StartWorkingDirectory>C:\github\CRFSharp\CRFSharpConsole\bin\Release\</StartWorkingDirectory>
+    <StartArguments>-encode -modelfile model.dat -trainfile input.txt -template template.txt -thread 2</StartArguments>
+    <StartWorkingDirectory>C:\Users\Dmitry\OneDrive\Ru\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <PublishUrlHistory>publish\</PublishUrlHistory>

--- a/CRFSharpConsole/EncoderConsole.cs
+++ b/CRFSharpConsole/EncoderConsole.cs
@@ -10,15 +10,15 @@ namespace CRFSharpConsole
     {
         public void Run(string [] args)
         {
-            CRFSharpWrapper.Encoder encoder = new CRFSharpWrapper.Encoder();
-            CRFSharpWrapper.EncoderArgs options = new EncoderArgs();
+            var encoder = new CRFSharpWrapper.Encoder();
+            var options = new EncoderArgs();
 
-            for (int i = 0; i < args.Length; i++)
+            for (var i = 0; i < args.Length; i++)
             {
                 if (args[i][0] == '-')
                 {
-                    string key = args[i].Substring(1).ToLower().Trim();
-                    string value = "";
+                    var key = args[i].Substring(1).ToLower().Trim();
+                    var value = "";
 
                     if (key == "encode")
                     {
@@ -33,7 +33,7 @@ namespace CRFSharpConsole
                         {
                             if (i < args.Length - 1)
                             {
-                                int debugLevel = int.Parse(args[i + 1]);
+                                var debugLevel = int.Parse(args[i + 1]);
                                 options.debugLevel = debugLevel;
                                 i++;
                             }
@@ -96,7 +96,7 @@ namespace CRFSharpConsole
                                 }
                                 break;
                             default:
-                                ConsoleColor cc = Console.ForegroundColor;
+                                var cc = Console.ForegroundColor;
                                 Console.ForegroundColor = ConsoleColor.Red;
                                 Console.WriteLine("No supported {0} parameter, exit", key);
                                 Console.ForegroundColor = cc;
@@ -106,7 +106,7 @@ namespace CRFSharpConsole
                     }
                     else
                     {
-                        ConsoleColor cc = Console.ForegroundColor;
+                        var cc = Console.ForegroundColor;
                         Console.ForegroundColor = ConsoleColor.Red;
                         Console.WriteLine("{0} is invalidated parameter.", key);
                         Console.ForegroundColor = cc;

--- a/CRFSharpConsole/Program.cs
+++ b/CRFSharpConsole/Program.cs
@@ -24,12 +24,13 @@ namespace CRFSharpConsole
                 return;
             }
 
-            bool bEncoder = false;
-            bool bDecoder = false;
-            bool bShrink = false;
+            var bEncoder = false;
+            var bDecoder = false;
+            var bShrink = false;
 
-            foreach (string item in args)
+            for (int index = 0; index < args.Length; index++)
             {
+                var item = args[index];
                 if (item.Length <= 1)
                 {
                     continue;
@@ -40,7 +41,7 @@ namespace CRFSharpConsole
                     continue;
                 }
 
-                string strType = item.Substring(1).ToLower().Trim();
+                var strType = item.Substring(1).ToLower().Trim();
                 if (strType == "encode")
                 {
                     bEncoder = true;
@@ -64,26 +65,26 @@ namespace CRFSharpConsole
 
             //try
             //{
-                if (bEncoder == true)
-                {
-                    EncoderConsole encoderConsole = new EncoderConsole();
-                    encoderConsole.Run(args);
-                }
-                else if (bDecoder == true)
-                {
-                    DecoderConsole decoderConsole = new DecoderConsole();
-                    decoderConsole.Run(args);
-                }
-                else if (bShrink == true)
-                {
-                    ShrinkConsole shrinkConsole = new ShrinkConsole();
-                    shrinkConsole.Run(args);
-                }
-                else
-                {
-                    Usage();
-                }
-           // }
+            if (bEncoder == true)
+            {
+                var encoderConsole = new EncoderConsole();
+                encoderConsole.Run(args);
+            }
+            else if (bDecoder == true)
+            {
+                var decoderConsole = new DecoderConsole();
+                decoderConsole.Run(args);
+            }
+            else if (bShrink == true)
+            {
+                var shrinkConsole = new ShrinkConsole();
+                shrinkConsole.Run(args);
+            }
+            else
+            {
+                Usage();
+            }
+            // }
             //catch (System.AggregateException err)
             //{
             //    Console.WriteLine("Error Message : {0}", err.Message);

--- a/CRFSharpConsole/ShrinkConsole.cs
+++ b/CRFSharpConsole/ShrinkConsole.cs
@@ -16,7 +16,7 @@ namespace CRFSharpConsole
                 return;
             }
 
-            CRFSharpWrapper.Shrink shrink = new Shrink();
+            var shrink = new Shrink();
             shrink.Process(args[1], args[2], int.Parse(args[3]));
         }
     }

--- a/Core/CRFSharp/base/BaseModel.cs
+++ b/Core/CRFSharp/base/BaseModel.cs
@@ -42,9 +42,9 @@ namespace CRFSharp
             }
             i++;
 
-            int col = 0;
-            int row = 0;
-            int neg = 1;
+            var col = 0;
+            var row = 0;
+            var neg = 1;
 
             if (p[i] == '-')
             {
@@ -90,7 +90,7 @@ namespace CRFSharp
             {
                 return null;
             }
-            int idx = pos + row;
+            var idx = pos + row;
             if (idx < 0)
             {
                 return "_B-" + (-idx).ToString();
@@ -105,9 +105,9 @@ namespace CRFSharp
 
         public string apply_rule(string p, int pos, Tagger tagger)
         {
-            StringBuilder feature_function = new StringBuilder();
+            var feature_function = new StringBuilder();
             string r;
-            for (int i = 0; i < p.Length; i++)
+            for (var i = 0; i < p.Length; i++)
             {
                 if (p[i] == '%')
                 {

--- a/Core/CRFSharp/base/Tagger.cs
+++ b/Core/CRFSharp/base/Tagger.cs
@@ -19,21 +19,22 @@ namespace CRFSharp
         //Calculate the cost of each path. It's used for finding the best or N-best result
         public int viterbi()
         {
-            double bestc = double.MinValue;
+            var bestc = double.MinValue;
             Node bestNode = null;
 
-            for (int i = 0; i < word_num; ++i)
+            for (var i = 0; i < word_num; ++i)
             {
-                for (int j = 0; j < ysize_; ++j)
+                for (var j = 0; j < ysize_; ++j)
                 {
                     bestc = double.MinValue;
                     bestNode = null;
 
-                    Node node_i_j = node_[i, j];
+                    var node_i_j = node_[i, j];
 
-                    foreach (CRFSharp.Path p in node_i_j.lpathList)
+                    for (int index = 0; index < node_i_j.lpathList.Count; index++)
                     {
-                        double cost = p.lnode.bestCost + p.cost + node_i_j.cost;
+                        var p = node_i_j.lpathList[index];
+                        var cost = p.lnode.bestCost + p.cost + node_i_j.cost;
                         if (cost > bestc)
                         {
                             bestc = cost;
@@ -49,7 +50,7 @@ namespace CRFSharp
             bestc = double.MinValue;
             bestNode = null;
 
-            short s = (short)(word_num - 1);
+            var s = (short)(word_num - 1);
             for (short j = 0; j < ysize_; ++j)
             {
                 if (bestc < node_[s, j].bestCost)
@@ -59,7 +60,7 @@ namespace CRFSharp
                 }
             }
 
-            Node n = bestNode;
+            var n = bestNode;
             while (n != null)
             {
                 result_[n.x] = n.y;
@@ -73,12 +74,13 @@ namespace CRFSharp
 
         private void calcAlpha(int m, int n)
         {
-            Node nd = node_[m, n];
+            var nd = node_[m, n];
             nd.alpha = 0.0;
 
-            int i = 0;
-            foreach (CRFSharp.Path p in nd.lpathList)
+            var i = 0;
+            for (int index = 0; index < nd.lpathList.Count; index++)
             {
+                var p = nd.lpathList[index];
                 nd.alpha = Utils.logsumexp(nd.alpha, p.cost + p.lnode.alpha, (i == 0));
                 i++;
             }
@@ -87,13 +89,14 @@ namespace CRFSharp
 
         private void calcBeta(int m, int n)
         {
-            Node nd = node_[m, n];
+            var nd = node_[m, n];
             nd.beta = 0.0f;
             if (m + 1 < word_num)
             {
-                int i = 0;
-                foreach (CRFSharp.Path p in nd.rpathList)
+                var i = 0;
+                for (int index = 0; index < nd.rpathList.Count; index++)
                 {
+                    var p = nd.rpathList[index];
                     nd.beta = Utils.logsumexp(nd.beta, p.cost + p.rnode.beta, (i == 0));
                     i++;
                 }
@@ -105,7 +108,7 @@ namespace CRFSharp
         {
             for (int i = 0, k = word_num - 1; i < word_num; ++i, --k)
             {
-                for (int j = 0; j < ysize_; ++j)
+                for (var j = 0; j < ysize_; ++j)
                 {
                     calcAlpha(i, j);
                     calcBeta(k, j);
@@ -113,7 +116,7 @@ namespace CRFSharp
             }
 
             Z_ = 0.0;
-            for (int j = 0; j < ysize_; ++j)
+            for (var j = 0; j < ysize_; ++j)
             {
                 Z_ = Utils.logsumexp(Z_, node_[0, j].beta, j == 0);
             }
@@ -123,7 +126,7 @@ namespace CRFSharp
         //Assign feature ids to node and path
         public int RebuildFeatures()
         {
-            int fid = 0;
+            var fid = 0;
             for (short cur = 0; cur < word_num; cur++)
             {
                 for (short i = 0; i < ysize_; i++)
@@ -133,12 +136,13 @@ namespace CRFSharp
                 fid++;
             }
 
-            for (int cur = 1; cur < word_num; cur++)
+            for (var cur = 1; cur < word_num; cur++)
             {
-                for (int j = 0; j < ysize_; ++j)
+                for (var j = 0; j < ysize_; ++j)
                 {
-                    foreach (CRFSharp.Path path in node_[cur - 1, j].rpathList)
+                    for (int index = 0; index < node_[cur - 1, j].rpathList.Count; index++)
                     {
+                        var path = node_[cur - 1, j].rpathList[index];
                         path.fid = fid;
                     }
                 }

--- a/Core/CRFSharp/base/Utils.cs
+++ b/Core/CRFSharp/base/Utils.cs
@@ -56,7 +56,7 @@ namespace CRFSharp
             H.elem_ptr_list = new List<QueueElement>(max_size + 1);
             H.elem_list = new List<QueueElement>(max_size + 1);
 
-            for (int z = 0; z < max_size; z++)
+            for (var z = 0; z < max_size; z++)
             {
                 H.elem_list.Add(new QueueElement());
                 H.elem_ptr_list.Add(null);
@@ -85,7 +85,7 @@ namespace CRFSharp
             {
                 return Utils.ERROR_HEAP_SIZE_TOO_BIG;
             }
-            int i = ++H.size;
+            var i = ++H.size;
             while (i != 1 && H.elem_ptr_list[i / 2].fx > qe.fx)
             {
                 H.elem_ptr_list[i] = H.elem_ptr_list[i / 2];  //此时i还没有进行i/2操作		
@@ -97,8 +97,8 @@ namespace CRFSharp
 
         public static QueueElement heap_delete_min(Heap H)
         {
-            QueueElement min_elem = H.elem_ptr_list[1];  //堆是从第1号元素开始的
-            QueueElement last_elem = H.elem_ptr_list[H.size--];
+            var min_elem = H.elem_ptr_list[1];  //堆是从第1号元素开始的
+            var last_elem = H.elem_ptr_list[H.size--];
             int i = 1, ci = 2;
             while (ci <= H.size)
             {
@@ -160,8 +160,8 @@ namespace CRFSharp
         public static double logsumexp(double x, double y, bool flg)
         {
             if (flg) return y;  // init mode
-            double vmin = Math.Min(x, y);
-            double vmax = Math.Max(x, y);
+            var vmin = Math.Min(x, y);
+            var vmax = Math.Max(x, y);
             if (vmax > vmin + MINUS_LOG_EPSILON)
             {
                 return vmax;

--- a/Core/CRFSharp/base/Utils.cs
+++ b/Core/CRFSharp/base/Utils.cs
@@ -159,17 +159,28 @@ namespace CRFSharp
 
         public static double logsumexp(double x, double y, bool flg)
         {
-            if (flg) return y;  // init mode
-            var vmin = Math.Min(x, y);
-            var vmax = Math.Max(x, y);
+            if (flg)
+            {
+                return y;  // init mode
+            }
+            double vmin;
+            double vmax;
+            if (x > y)
+            {
+                vmin = y;
+                vmax = x;
+            }
+            else
+            {
+                vmin = x;
+                vmax = y;
+            }
+
             if (vmax > vmin + MINUS_LOG_EPSILON)
             {
                 return vmax;
             }
-            else
-            {
-                return vmax + Math.Log(Math.Exp(vmin - vmax) + 1.0);
-            }
+            return vmax + Math.Log(Math.Exp(vmin - vmax) + 1.0);
         }
     }
 }

--- a/Core/CRFSharp/decoder/DecoderTagger.cs
+++ b/Core/CRFSharp/decoder/DecoderTagger.cs
@@ -70,7 +70,7 @@ namespace CRFSharp
         public void InitializeFeatureCache()
         {
             feature_cache_ = new List<long[]>();
-            int feature_cache_every_row_size = 0;
+            var feature_cache_every_row_size = 0;
             if (featureIndex.unigram_templs_.Count > featureIndex.bigram_templs_.Count)
             {
                 feature_cache_every_row_size = featureIndex.unigram_templs_.Count + 1;
@@ -79,10 +79,10 @@ namespace CRFSharp
             {
                 feature_cache_every_row_size = featureIndex.bigram_templs_.Count + 1;
             }
-            for (int i = 0; i < crf_max_word_num * 2; i++)
+            for (var i = 0; i < crf_max_word_num * 2; i++)
             {
-                long[] features = new long[feature_cache_every_row_size];
-                for (int j = 0; j < feature_cache_every_row_size; j++)
+                var features = new long[feature_cache_every_row_size];
+                for (var j = 0; j < feature_cache_every_row_size; j++)
                 {
                     features[j] = -1;
                 }
@@ -146,7 +146,7 @@ namespace CRFSharp
             {
                 for (short i = 0; i < ysize_; i++)
                 {
-                    Node n = new Node();
+                    var n = new Node();
                     node_[cur, i] = n;
 
                     n.lpathList = new List<Path>();
@@ -156,13 +156,13 @@ namespace CRFSharp
                 }
             }
 
-            for (int cur = 1; cur < crf_max_word_num; cur++)
+            for (var cur = 1; cur < crf_max_word_num; cur++)
             {
-                for (int j = 0; j < ysize_; ++j)
+                for (var j = 0; j < ysize_; ++j)
                 {
-                    for (int i = 0; i < ysize_; ++i)
+                    for (var i = 0; i < ysize_; ++i)
                     {
-                        CRFSharp.Path p = new CRFSharp.Path();
+                        var p = new CRFSharp.Path();
                         p.add(node_[cur - 1, j], node_[cur, i]);
                     }
                 }
@@ -173,10 +173,10 @@ namespace CRFSharp
 
         public int initNbest()
         {
-            int k = (int)word_num - 1;
-            for (int i = 0; i < ysize_; ++i)
+            var k = (int)word_num - 1;
+            for (var i = 0; i < ysize_; ++i)
             {
-                QueueElement eos = Utils.allc_from_heap(heap_queue);
+                var eos = Utils.allc_from_heap(heap_queue);
                 eos.node = node_[k,i];
                 eos.fx = -node_[k,i].bestCost;
                 eos.gx = -node_[k,i].cost;
@@ -193,12 +193,12 @@ namespace CRFSharp
         {
             while (!Utils.is_heap_empty(heap_queue))
             {
-                QueueElement top = Utils.heap_delete_min(heap_queue);
-                Node rnode = top.node;
+                var top = Utils.heap_delete_min(heap_queue);
+                var rnode = top.node;
 
                 if (rnode.x == 0)
                 {
-                    for (QueueElement n = top; n != null; n = n.next)
+                    for (var n = top; n != null; n = n.next)
                     {
                         result_[n.node.x] = n.node.y;
                     }
@@ -206,10 +206,11 @@ namespace CRFSharp
                     return 0;
                 }
 
-                foreach (Path p in rnode.lpathList)
+                for (int index = 0; index < rnode.lpathList.Count; index++)
                 {
-                    QueueElement n = Utils.allc_from_heap(heap_queue);
-                    int x_num = (rnode.x) - 1;
+                    var p = rnode.lpathList[index];
+                    var n = Utils.allc_from_heap(heap_queue);
+                    var x_num = (rnode.x) - 1;
                     n.node = p.lnode;
                     n.gx = -p.lnode.cost - p.cost + top.gx;
                     n.fx = -p.lnode.bestCost - p.cost + top.gx;
@@ -219,7 +220,6 @@ namespace CRFSharp
                     {
                         return Utils.ERROR_INSERT_HEAP_FAILED;
                     }
-
                 }
             }
             return 0;
@@ -240,13 +240,14 @@ namespace CRFSharp
             //Generate feature ids for all nodes and paths
             RebuildFeatures();
 
-            for (int i = 0; i < word_num; i++)
+            for (var i = 0; i < word_num; i++)
             {
-                for (int j = 0; j < ysize_; j++)
+                for (var j = 0; j < ysize_; j++)
                 {
                     calcCost(node_[i, j]);
-                    foreach (Path p in node_[i, j].lpathList)
+                    for (int index = 0; index < node_[i, j].lpathList.Count; index++)
                     {
+                        var p = node_[i, j].lpathList[index];
                         calcCost(p);
                     }
                 }
@@ -272,9 +273,9 @@ namespace CRFSharp
                 term_buf.prob = prob();
             }
 
-            short this_word_num = get_word_num();
+            var this_word_num = get_word_num();
 
-            for (int i = 0; i < this_word_num; ++i)
+            for (var i = 0; i < this_word_num; ++i)
             {
                 term_buf.result_[i] = yname(result_[i]);
                 switch (vlevel_)
@@ -295,7 +296,7 @@ namespace CRFSharp
         //Returen value: Successed - 0, Failed < 0
         public int parse()
         {
-            int ret = 0;
+            var ret = 0;
             //no word need to be labeled
             if (word_num == 0)
             {
@@ -354,15 +355,16 @@ namespace CRFSharp
                 return Utils.ERROR_INVALIDATED_PARAMETER;
             }
 
-            int id = 0;
-            int feature_cache_row_size = 0;
-            int feature_cache_size = 0;
-            for (int cur = 0; cur < word_num; cur++)
+            var id = 0;
+            var feature_cache_row_size = 0;
+            var feature_cache_size = 0;
+            for (var cur = 0; cur < word_num; cur++)
             {
                 feature_cache_row_size = 0;
-                foreach (string templ in featureIndex.unigram_templs_)
+                for (int index = 0; index < featureIndex.unigram_templs_.Count; index++)
                 {
-                    string strFeature = featureIndex.apply_rule(templ, cur, this);
+                    var templ = featureIndex.unigram_templs_[index];
+                    var strFeature = featureIndex.apply_rule(templ, cur, this);
                     if (strFeature == "")
                     {
                         return Utils.ERROR_EMPTY_FEATURE;
@@ -378,12 +380,13 @@ namespace CRFSharp
                 feature_cache_size++;
             }
 
-            for (int cur = 0; cur < word_num; cur++)
+            for (var cur = 0; cur < word_num; cur++)
             {
                 feature_cache_row_size = 0;
-                foreach (string templ in featureIndex.bigram_templs_)
+                for (int index = 0; index < featureIndex.bigram_templs_.Count; index++)
                 {
-                    string strFeature = featureIndex.apply_rule(templ, cur, this);
+                    var templ = featureIndex.bigram_templs_[index];
+                    var strFeature = featureIndex.apply_rule(templ, cur, this);
                     if (strFeature == "")
                     {
                         return Utils.ERROR_EMPTY_FEATURE;
@@ -408,8 +411,8 @@ namespace CRFSharp
         public void calcCost(Node n)
         {
             double c = 0;
-            long[] f = feature_cache_[n.fid];
-            for (int i = 0; i < f.Length && f[i] != -1; i++)
+            var f = feature_cache_[n.fid];
+            for (var i = 0; i < f.Length && f[i] != -1; i++)
             {
                 c += featureIndex.GetAlpha(f[i] + n.y);
             }
@@ -419,8 +422,8 @@ namespace CRFSharp
         public void calcCost(CRFSharp.Path p)
         {
             double c = 0;
-            long[] f = feature_cache_[p.fid];
-            for (int i = 0; i < f.Length && f[i] != -1; i++)
+            var f = feature_cache_[p.fid];
+            for (var i = 0; i < f.Length && f[i] != -1; i++)
             {
                 c += featureIndex.GetAlpha((int)(f[i] + p.lnode.y * ysize_ + p.rnode.y));
             }
@@ -430,8 +433,8 @@ namespace CRFSharp
 
         public int output(crf_term_out[] pout)
         {
-            int n = 0;
-            int ret = 0;
+            var n = 0;
+            var ret = 0;
 
             if (nbest_ == 1)
             {
@@ -445,7 +448,7 @@ namespace CRFSharp
             else
             {
                 //Fill the n best result
-                int iNBest = nbest_;
+                var iNBest = nbest_;
                 if (pout.Length < iNBest)
                 {
                     iNBest = pout.Length;

--- a/Core/CRFSharp/decoder/ModelReader.cs
+++ b/Core/CRFSharp/decoder/ModelReader.cs
@@ -23,7 +23,7 @@ namespace CRFSharp
         //返回值<0 为出错，=0为正常
         public bool LoadModel(string filename)
         {
-            StreamReader sr = new StreamReader(filename);
+            var sr = new StreamReader(filename);
             string strLine;
 
 
@@ -80,15 +80,15 @@ namespace CRFSharp
             sr.Close();
 
             //Load all feature set data
-            string filename_feature = filename + ".feature";
+            var filename_feature = filename + ".feature";
             da = new DoubleArrayTrieSearch();
             da.Load(filename_feature);
 
 
             //Load all features alpha data
-            string filename_alpha = filename + ".alpha";
-            StreamReader sr_alpha = new StreamReader(filename_alpha);
-            BinaryReader br_alpha = new BinaryReader(sr_alpha.BaseStream);
+            var filename_alpha = filename + ".alpha";
+            var sr_alpha = new StreamReader(filename_alpha);
+            var br_alpha = new BinaryReader(sr_alpha.BaseStream);
 
             if (version == Utils.MODEL_TYPE_NORM)
             {
@@ -106,7 +106,7 @@ namespace CRFSharp
                 alpha_two_tuples = new BTreeDictionary<long, double>();
                 for (long i = 0; i < maxid_; i++)
                 {
-                    long key = br_alpha.ReadInt64();
+                    var key = br_alpha.ReadInt64();
                     double weight = br_alpha.ReadSingle();
                     alpha_two_tuples.Add(key, weight);
                 }

--- a/Core/CRFSharp/encoder/CRFEncoderThread.cs
+++ b/Core/CRFSharp/encoder/CRFEncoderThread.cs
@@ -28,9 +28,9 @@ namespace CRFSharp
                 return;
             }
 
-            short ysize_ = x[0].ysize_;
+            var ysize_ = x[0].ysize_;
             max_xsize_ = 0;
-            for (int i = start_i; i < x.Length; i += thread_num)
+            for (var i = start_i; i < x.Length; i += thread_num)
             {
                 if (max_xsize_ < x[i].word_num)
                 {
@@ -40,9 +40,9 @@ namespace CRFSharp
 
             result_ = new short[max_xsize_];
             node_ = new Node[max_xsize_, ysize_];
-            for (int i = 0; i < max_xsize_; i++)
+            for (var i = 0; i < max_xsize_; i++)
             {
-                for (int j = 0; j < ysize_; j++)
+                for (var j = 0; j < ysize_; j++)
                 {
                     node_[i, j] = new Node();
                     node_[i, j].x = (short)i;
@@ -58,7 +58,7 @@ namespace CRFSharp
                 {
                     for (short i = 0; i < ysize_; ++i)
                     {
-                        Path path = new Path();
+                        var path = new Path();
                         path.fid = -1;
                         path.cost = 0.0;
                         path.add(node_[cur - 1, j], node_[cur, i]);
@@ -76,11 +76,11 @@ namespace CRFSharp
             err = zeroone = 0;
             //expected.Clear();
             Array.Clear(merr, 0, merr.Length);
-            for (int i = start_i; i < x.Length; i += thread_num)
+            for (var i = start_i; i < x.Length; i += thread_num)
             {
                 x[i].Init(result_, node_);
                 obj += x[i].gradient(lbfgs.expected);
-                int error_num = x[i].eval(merr);
+                var error_num = x[i].eval(merr);
                 err += error_num;
                 if (error_num > 0)
                 {

--- a/Core/CRFSharp/encoder/DefaultFeatureLexicalDict.cs
+++ b/Core/CRFSharp/encoder/DefaultFeatureLexicalDict.cs
@@ -49,7 +49,7 @@ namespace CRFSharp
 
         public void Shrink(int freq)
         {
-            int i = 0;
+            var i = 0;
             while (i < featureset_dict_.Count)
             {
                 if (featureset_dict_.ValueList[i].Value < freq)
@@ -67,7 +67,7 @@ namespace CRFSharp
         public void GenerateLexicalIdList(out IList<string> keyList, out IList<int> valList)
         {
             keyList = featureset_dict_.KeyList;
-            int [] fixArrayValue = new int[Size];
+            var fixArrayValue = new int[Size];
             valList = fixArrayValue;
 
 #if NO_SUPPORT_PARALLEL_LIB
@@ -89,14 +89,14 @@ namespace CRFSharp
         {
             long new_maxid = 0;
             //Regenerate new feature id and create feature ids mapping
-            foreach (KeyValuePair<string, FeatureIdPair> it in featureset_dict_)
+            foreach (var it in featureset_dict_)
             {
-                string strFeature = it.Key;
+                var strFeature = it.Key;
                 //Regenerate new feature id
                 old2new.Add(it.Value.Key, new_maxid);
                 it.Value.Key = new_maxid;
 
-                long addValue = (strFeature[0] == 'U' ? ysize : ysize * ysize);
+                var addValue = (strFeature[0] == 'U' ? ysize : ysize * ysize);
                 new_maxid += addValue;
             }
 
@@ -134,7 +134,7 @@ namespace CRFSharp
                     }
                     else
                     {
-                        long oldValue = Interlocked.Increment(ref maxid_) - 1;
+                        var oldValue = Interlocked.Increment(ref maxid_) - 1;
                         pair = new FeatureIdPair(oldValue, 1);
                         featureset_dict_.Add(key, pair);
                     }

--- a/Core/CRFSharp/encoder/HugeFeatureLexicalDict.cs
+++ b/Core/CRFSharp/encoder/HugeFeatureLexicalDict.cs
@@ -102,7 +102,7 @@ namespace CRFSharp
 #else
         private long ParallelMerge(long startIndex, long endIndex, int freq)
         {
-            long sizePerThread = (endIndex - startIndex + 1) / parallelOption.MaxDegreeOfParallelism;
+            var sizePerThread = (endIndex - startIndex + 1) / parallelOption.MaxDegreeOfParallelism;
             //Fistly, merge items in each block by parallel
             Parallel.For(0, parallelOption.MaxDegreeOfParallelism, parallelOption, i =>
             {
@@ -124,7 +124,7 @@ namespace CRFSharp
         //Merge same items in sorted list
         private long Merge(long startIndex, long endIndex, int freq)
         {
-            long newEndIndex = startIndex;
+            var newEndIndex = startIndex;
 
             //Try to find first not null item
             while ((arrayFeatureFreq[startIndex] == null) &&
@@ -133,7 +133,7 @@ namespace CRFSharp
                 startIndex++;
             }
             arrayFeatureFreq[newEndIndex] = arrayFeatureFreq[startIndex];
-            for (long i = startIndex + 1; i <= endIndex; i++)
+            for (var i = startIndex + 1; i <= endIndex; i++)
             {
                 if (arrayFeatureFreq[i] == null)
                 {
@@ -168,10 +168,10 @@ namespace CRFSharp
         //Generate feature string and its id list
         public void GenerateLexicalIdList(out IList<string> keyList, out IList<int> valList)
         {
-            FixedBigArray<string> fixArrayKey = new FixedBigArray<string>(Size, 0);
+            var fixArrayKey = new FixedBigArray<string>(Size, 0);
             keyList = fixArrayKey;
 
-            FixedBigArray<int> fixArrayValue = new FixedBigArray<int>(Size, 0);
+            var fixArrayValue = new FixedBigArray<int>(Size, 0);
             valList = fixArrayValue;
 
 #if NO_SUPPORT_PARALLEL_LIB
@@ -193,7 +193,7 @@ namespace CRFSharp
         //Generate feature id by NGram rules
         public long RegenerateFeatureId(BTreeDictionary<long, long> old2new, long ysize)
         {
-            AdvUtils.Security.Cryptography.MD5 md5 = new AdvUtils.Security.Cryptography.MD5();
+            var md5 = new AdvUtils.Security.Cryptography.MD5();
             long maxid_ = 0;
 
 #if NO_SUPPORT_PARALLEL_LIB
@@ -203,8 +203,8 @@ namespace CRFSharp
 #endif
             {
                 //Generate new feature id
-                long addValue = (arrayFeatureFreq[i].strFeature[0] == 'U' ? ysize : ysize * ysize);
-                long oldValue = maxid_;
+                var addValue = (arrayFeatureFreq[i].strFeature[0] == 'U' ? ysize : ysize * ysize);
+                var oldValue = maxid_;
                 while (System.Threading.Interlocked.CompareExchange(ref maxid_, oldValue + addValue, oldValue) != oldValue)
                 {
                     oldValue = maxid_;
@@ -230,7 +230,7 @@ namespace CRFSharp
         //Shrink entire list
         public void Shrink(int freq)
         {
-            long newEndIndex = Shrink(0, arrayFeatureFreqSize - 1, freq);
+            var newEndIndex = Shrink(0, arrayFeatureFreqSize - 1, freq);
             arrayFeatureFreqSize = newEndIndex + 1;
         }
 
@@ -249,7 +249,7 @@ namespace CRFSharp
 #if NO_SUPPORT_PARALLEL_LIB
             long newEndIndex = Merge(startIndex, endIndex, freq);
 #else
-            long newEndIndex = ParallelMerge(startIndex, endIndex, freq);
+            var newEndIndex = ParallelMerge(startIndex, endIndex, freq);
 #endif
             sortedEndIndex = newEndIndex;
 
@@ -263,7 +263,7 @@ namespace CRFSharp
         //Get feature string id
         private long GetId(string strFeature)
         {
-            byte[] rawbytes = Encoding.UTF8.GetBytes(strFeature);
+            var rawbytes = Encoding.UTF8.GetBytes(strFeature);
             
             lock (thisLock)
             {
@@ -282,12 +282,12 @@ namespace CRFSharp
             //add item-adding lock
             Interlocked.Increment(ref AddLock);
 
-            FeatureFreq newFFItem = new FeatureFreq();
+            var newFFItem = new FeatureFreq();
             newFFItem.strFeature = strFeature;
             newFFItem.value = 1;
             if (sortedEndIndex > 0)
             {
-                FeatureFreq ff = arrayFeatureFreq.BinarySearch(0, sortedEndIndex, newFFItem);
+                var ff = arrayFeatureFreq.BinarySearch(0, sortedEndIndex, newFFItem);
                 if (ff != null)
                 {
                     Interlocked.Increment(ref ff.value);
@@ -297,7 +297,7 @@ namespace CRFSharp
                 }
             }
 
-            long oldValue = Interlocked.Increment(ref arrayFeatureFreqSize) - 1;
+            var oldValue = Interlocked.Increment(ref arrayFeatureFreqSize) - 1;
             arrayFeatureFreq[oldValue] = newFFItem;
 
             //free item-adding lock
@@ -307,7 +307,7 @@ namespace CRFSharp
             uint memoryLoad = 0;
             if (oldValue % 10000000 == 0)
             {
-                MEMORYSTATUSEX msex = new MEMORYSTATUSEX();
+                var msex = new MEMORYSTATUSEX();
                 GlobalMemoryStatusEx(msex);
                 memoryLoad = msex.dwMemoryLoad;
             }
@@ -317,15 +317,15 @@ namespace CRFSharp
                 if (Interlocked.CompareExchange(ref ShrinkingLock, 1, 0) == 0)
                 {
                     //Double check whether shrink should be started
-                    MEMORYSTATUSEX msex = new MEMORYSTATUSEX();
+                    var msex = new MEMORYSTATUSEX();
                     GlobalMemoryStatusEx(msex);
                     if (msex.dwMemoryLoad >= SHRINK_AVALI_MEM_LOAD)
                     {
                         while (AddLock != 0) { Thread.Sleep(1000); }
 
-                        DateTime startDT = DateTime.Now;
+                        var startDT = DateTime.Now;
                         Console.WriteLine("Begin to shrink [Feature Size: {0}]...", arrayFeatureFreqSize);
-                        long newArrayFeatureFreqSize = Shrink(0, arrayFeatureFreqSize - 1, 0) + 1;
+                        var newArrayFeatureFreqSize = Shrink(0, arrayFeatureFreqSize - 1, 0) + 1;
 
                         GlobalMemoryStatusEx(msex);
                         if (msex.dwMemoryLoad >= SHRINK_AVALI_MEM_LOAD - 1)
@@ -340,7 +340,7 @@ namespace CRFSharp
                         }
 
                         arrayFeatureFreqSize = newArrayFeatureFreqSize;
-                        TimeSpan ts = DateTime.Now - startDT;
+                        var ts = DateTime.Now - startDT;
                         Console.WriteLine("Shrink has been done!");
                         Console.WriteLine("[Feature Size:{0}, TimeSpan:{1}, Next Shrink Rate:{2}%]", arrayFeatureFreqSize, ts, SHRINK_AVALI_MEM_LOAD);
                     }

--- a/Core/CRFSharp/encoder/LBFGS.cs
+++ b/Core/CRFSharp/encoder/LBFGS.cs
@@ -79,7 +79,7 @@ namespace CRFSharp
 
         void pseudo_gradient(double[] x, double C)
         {
-            long size = expected.LongLength - 1;
+            var size = expected.LongLength - 1;
 #if NO_SUPPORT_PARALLEL_LIB
             for (long i = 1; i < size + 1;i++)
 #else
@@ -121,7 +121,7 @@ namespace CRFSharp
         public int optimize(double[] x, double C, bool orthant)
         {
             const long msize = 5;
-            long size = x.LongLength - 1;
+            var size = x.LongLength - 1;
             if (w == null || w.LongLength == 0)
             {
                 iflag_ = 0;
@@ -155,12 +155,12 @@ namespace CRFSharp
 
         void lbfgs_optimize(long msize, double[] x, bool orthant, double C)
         {
-            long size = x.LongLength - 1;
-            double yy = 0.0;
-            double ys = 0.0;
+            var size = x.LongLength - 1;
+            var yy = 0.0;
+            var ys = 0.0;
             long bound = 0;
             long cp = 0;
-            bool bExit = false;
+            var bExit = false;
 
             // initialization
             if (iflag_ == 0)
@@ -241,7 +241,7 @@ namespace CRFSharp
                 ys = ddot_(size, w, iypt + npt + 1, w, ispt + npt + 1);
                 yy = ddot_(size, w, iypt + npt + 1, w, iypt + npt + 1);
 
-                double r_ys_yy = ys / yy;
+                var r_ys_yy = ys / yy;
 #if NO_SUPPORT_PARALLEL_LIB
                 for (long i = 1;i < size + 1;i++)
 #else
@@ -266,15 +266,15 @@ namespace CRFSharp
                 //回退次数
                 bound = Math.Min(iter - 1, msize);
                 cp = point;
-                for (int i = 1; i <= bound; ++i)
+                for (var i = 1; i <= bound; ++i)
                 {
                     --cp;
                     if (cp == -1) cp = msize - 1;
-                    double sq = ddot_(size, w, ispt + cp * size + 1, w, 1);
-                    long inmc = size + msize + cp + 1;
-                    long iycn = iypt + cp * size;
+                    var sq = ddot_(size, w, ispt + cp * size + 1, w, 1);
+                    var inmc = size + msize + cp + 1;
+                    var iycn = iypt + cp * size;
                     w[inmc] = (w[size + cp + 1] * sq);
-                    double d = -w[inmc];
+                    var d = -w[inmc];
 
 #if NO_SUPPORT_PARALLEL_LIB
                     for (long j = 1;j < size + 1;j++)
@@ -303,13 +303,13 @@ namespace CRFSharp
                 );
 #endif
 
-                for (int i = 1; i <= bound; ++i)
+                for (var i = 1; i <= bound; ++i)
                 {
-                    double yr = ddot_(size, w, iypt + cp * size + 1, w, 1);
-                    double beta = w[size + cp + 1] * yr;
-                    long inmc = size + msize + cp + 1;
+                    var yr = ddot_(size, w, iypt + cp * size + 1, w, 1);
+                    var beta = w[size + cp + 1] * yr;
+                    var inmc = size + msize + cp + 1;
                     beta = w[inmc] - beta;
-                    long iscn = ispt + cp * size;
+                    var iscn = ispt + cp * size;
 
 #if NO_SUPPORT_PARALLEL_LIB
                     for (long j = 1;j < size + 1;j++)
@@ -349,7 +349,7 @@ namespace CRFSharp
 
 
                 // STORE THE NEW SEARCH DIRECTION
-                long offset = ispt + point * size;
+                var offset = ispt + point * size;
 
 #if NO_SUPPORT_PARALLEL_LIB
                 for (long i = 1;i < size + 1;i++)
@@ -373,8 +373,8 @@ namespace CRFSharp
 
         private bool LineSearchAndUpdateStepGradient(long msize, double[] x, bool orthant)
         {
-            long size = x.LongLength - 1;
-            bool bExit = false;
+            var size = x.LongLength - 1;
+            var bExit = false;
             mcsrch_.mcsrch(x, obj, v, w, ispt + point * size,
                             ref stp, ref info, ref nfev, diag);
             if (info == -1)
@@ -430,8 +430,8 @@ namespace CRFSharp
                     point = 0;
                 }
 
-                double gnorm = Math.Sqrt(ddot_(size, v, 1, v, 1));
-                double xnorm = Math.Max(1.0, Math.Sqrt(ddot_(size, x, 1, x, 1)));
+                var gnorm = Math.Sqrt(ddot_(size, v, 1, v, 1));
+                var xnorm = Math.Max(1.0, Math.Sqrt(ddot_(size, x, 1, x, 1)));
                 if (gnorm / xnorm <= Utils.eps)
                 {
                     iflag_ = 0;  // OK terminated

--- a/Core/CRFSharp/encoder/Mcsrch.cs
+++ b/Core/CRFSharp/encoder/Mcsrch.cs
@@ -64,7 +64,7 @@ namespace CRFSharp
             double stpmin, double stpmax,
             ref int info)
         {
-            bool bound = true;
+            var bound = true;
             double p, q, d3, r, stpq, stpc, stpf;
             double gamma;
             double s;
@@ -78,7 +78,7 @@ namespace CRFSharp
                 return;
             }
 
-            double sgnd = dp * (dx / Math.Abs(dx));
+            var sgnd = dp * (dx / Math.Abs(dx));
             if (fp > fx)
             {
                 info = 1;
@@ -326,15 +326,15 @@ namespace CRFSharp
         public void mcsrch(double[] x, double f, double[] g, double[] s, long s_idx,
             ref double stp, ref long info, ref long nfev, double[] wa)
         {
-            long size = x.LongLength - 1;
+            var size = x.LongLength - 1;
             /* Parameter adjustments */
             if (info == -1)
             {
                 info = 0;
                 nfev++;
 
-                double dg = ddot_(size, g, 1, s, s_idx + 1);
-                double ftest1 = finit + stp * dgtest;
+                var dg = ddot_(size, g, 1, s, s_idx + 1);
+                var ftest1 = finit + stp * dgtest;
 
                 if (brackt && ((stp <= stmin || stp >= stmax) || infoc == 0))
                 {
@@ -380,12 +380,12 @@ namespace CRFSharp
 
                 if (stage1 && f <= fx && f > ftest1)
                 {
-                    double fm = f - stp * dgtest;
-                    double fxm = fx - stx * dgtest;
-                    double fym = fy - sty * dgtest;
-                    double dgm = dg - dgtest;
-                    double dgxm = dgx - dgtest;
-                    double dgym = dgy - dgtest;
+                    var fm = f - stp * dgtest;
+                    var fxm = fx - stx * dgtest;
+                    var fym = fy - sty * dgtest;
+                    var dgm = dg - dgtest;
+                    var dgxm = dgx - dgtest;
+                    var dgym = dgy - dgtest;
                     mcstep(ref stx, ref fxm, ref dgxm, ref sty, ref fym, ref dgym, ref stp, fm, dgm, ref brackt,
                            stmin, stmax, ref infoc);
                     fx = fxm + stx * dgtest;
@@ -401,7 +401,7 @@ namespace CRFSharp
 
                 if (brackt)
                 {
-                    double d1 = 0.0;
+                    var d1 = 0.0;
                     d1 = sty - stx;
                     if (Math.Abs(d1) >= p66 * width1)
                     {
@@ -476,7 +476,7 @@ namespace CRFSharp
                 stp = stx;
             }
 
-            double stp_t = stp;
+            var stp_t = stp;
 
 #if NO_SUPPORT_PARALLEL_LIB
             for (long i = 1;i < size + 1;i++)

--- a/Core/CRFSharp/encoder/ModelWritter.cs
+++ b/Core/CRFSharp/encoder/ModelWritter.cs
@@ -52,10 +52,10 @@ namespace CRFSharp
         //Regenerate feature id and shrink features with lower frequency
         public void Shrink(EncoderTagger[] xList, int freq)
         {
-            BTreeDictionary<long, long> old2new = new BTreeDictionary<long, long>();
+            var old2new = new BTreeDictionary<long, long>();
             featureLexicalDict.Shrink(freq);
             maxid_ = featureLexicalDict.RegenerateFeatureId(old2new, y_.Count);
-            int feature_count = xList.Length;
+            var feature_count = xList.Length;
 
             //Update feature ids
 #if NO_SUPPORT_PARALLEL_LIB
@@ -64,12 +64,13 @@ namespace CRFSharp
             Parallel.For(0, feature_count, parallelOption, i =>
 #endif
             {
-                for (int j = 0; j < xList[i].feature_cache_.Count; j++)
+                for (var j = 0; j < xList[i].feature_cache_.Count; j++)
                 {
-                    List<long> newfs = new List<long>();
+                    var newfs = new List<long>();
                     long rstValue = 0;
-                    foreach (long v in xList[i].feature_cache_[j])
+                    for (int index = 0; index < xList[i].feature_cache_[j].Length; index++)
                     {
+                        var v = xList[i].feature_cache_[j][index];
                         if (old2new.TryGetValue(v, out rstValue) == true)
                         {
                             newfs.Add(rstValue);
@@ -80,7 +81,7 @@ namespace CRFSharp
             }
 #if NO_SUPPORT_PARALLEL_LIB
 #else
-            );
+);
 #endif
 
             Console.WriteLine("Feature size in total : {0}", maxid_);
@@ -89,8 +90,8 @@ namespace CRFSharp
         //Load all records and generate features
         public EncoderTagger[] ReadAllRecords()
         {
-            EncoderTagger[] arrayEncoderTagger = new EncoderTagger[trainCorpusList.Count];
-            int arrayEncoderTaggerSize = 0;
+            var arrayEncoderTagger = new EncoderTagger[trainCorpusList.Count];
+            var arrayEncoderTaggerSize = 0;
 
             //Generate each record features
 #if NO_SUPPORT_PARALLEL_LIB
@@ -99,14 +100,14 @@ namespace CRFSharp
             Parallel.For(0, trainCorpusList.Count, parallelOption, i =>
 #endif
             {
-                EncoderTagger _x = new EncoderTagger(this);
+                var _x = new EncoderTagger(this);
                 if (_x.GenerateFeature(trainCorpusList[i]) == false)
                 {
                     Console.WriteLine("Load a training sentence failed, skip it.");
                 }
                 else
                 {
-                    int oldValue = Interlocked.Increment(ref arrayEncoderTaggerSize) - 1;
+                    var oldValue = Interlocked.Increment(ref arrayEncoderTaggerSize) - 1;
                     arrayEncoderTagger[oldValue] = _x;
 
                     if (oldValue % 10000 == 0)
@@ -118,7 +119,7 @@ namespace CRFSharp
             }
 #if NO_SUPPORT_PARALLEL_LIB
 #else
-            );
+);
 #endif
 
             trainCorpusList.Clear();
@@ -146,10 +147,10 @@ namespace CRFSharp
             if (debugLevel > 0)
             {
                 Console.Write("Debug: Writing raw feature set into file...");
-                string filename_featureset_raw_format = filename + ".feature.raw_text";
-                StreamWriter sw = new StreamWriter(filename_featureset_raw_format);
+                var filename_featureset_raw_format = filename + ".feature.raw_text";
+                var sw = new StreamWriter(filename_featureset_raw_format);
                 // save feature and its id into lists in raw format
-                for (int i = 0; i < keyList.Count; i++)
+                for (var i = 0; i < keyList.Count; i++)
                 {
                     sw.WriteLine("{0}\t{1}", keyList[i], valList[i]);
                 }
@@ -158,8 +159,8 @@ namespace CRFSharp
             }
 
             //Build feature index
-            string filename_featureset = filename + ".feature";
-            DoubleArrayTrieBuilder da = new DoubleArrayTrieBuilder(thread_num_);
+            var filename_featureset = filename + ".feature";
+            var da = new DoubleArrayTrieBuilder(thread_num_);
             if (da.build(keyList, valList, max_slot_usage_rate_threshold) == false)
             {
                 Console.WriteLine("Build lexical dictionary failed.");
@@ -188,20 +189,20 @@ namespace CRFSharp
                 //Create weight matrix
                 alpha_ = new double[feature_size() + 1];
 
-                ModelReader modelReader = new ModelReader();
+                var modelReader = new ModelReader();
                 modelReader.LoadModel(strRetrainModelFileName);
 
                 if (modelReader.y_.Count == y_.Count)
                 {
-                    for (int i = 0; i < keyList.Count; i++)
+                    for (var i = 0; i < keyList.Count; i++)
                     {
-                        int index = modelReader.get_id(keyList[i]);
+                        var index = modelReader.get_id(keyList[i]);
                         if (index < 0)
                         {
                             continue;
                         }
-                        int size = (keyList[i][0] == 'U' ? y_.Count : y_.Count * y_.Count);
-                        for (int j = 0; j < size; j++)
+                        var size = (keyList[i][0] == 'U' ? y_.Count : y_.Count * y_.Count);
+                        for (var j = 0; j < size; j++)
                         {
                             alpha_[valList[i] + j + 1] = modelReader.GetAlpha(index + j);
                         }
@@ -227,7 +228,7 @@ namespace CRFSharp
         //Save model meta data into file
         public bool SaveModelMetaData(string filename)
         {
-            StreamWriter tofs = new StreamWriter(filename);
+            var tofs = new StreamWriter(filename);
 
             // header
             tofs.WriteLine("version: " + Utils.MODEL_TYPE_NORM);
@@ -238,18 +239,18 @@ namespace CRFSharp
             tofs.WriteLine();
 
             // y
-            for (int i = 0; i < y_.Count; ++i)
+            for (var i = 0; i < y_.Count; ++i)
             {
                 tofs.WriteLine(y_[i]);
             }
             tofs.WriteLine();
 
             // template
-            for (int i = 0; i < unigram_templs_.Count; ++i)
+            for (var i = 0; i < unigram_templs_.Count; ++i)
             {
                 tofs.WriteLine(unigram_templs_[i]);
             }
-            for (int i = 0; i < bigram_templs_.Count; ++i)
+            for (var i = 0; i < bigram_templs_.Count; ++i)
             {
                 tofs.WriteLine(bigram_templs_[i]);
             }
@@ -262,27 +263,27 @@ namespace CRFSharp
 
         public bool SaveFeatureWeight(string filename)
         {
-            string filename_alpha = filename + ".alpha";
-            StreamWriter tofs = new StreamWriter(filename_alpha, false);
-            BinaryWriter bw = new BinaryWriter(tofs.BaseStream);
+            var filename_alpha = filename + ".alpha";
+            var tofs = new StreamWriter(filename_alpha, false);
+            var bw = new BinaryWriter(tofs.BaseStream);
 
             for (long i = 1; i <= maxid_; ++i)
             {
                 bw.Write((float)alpha_[i]);
             }
-  
+
             bw.Close();
             return true;
         }
 
         bool OpenTemplateFile(string filename)
         {
-            StreamReader ifs = new StreamReader(filename);
+            var ifs = new StreamReader(filename);
             unigram_templs_ = new List<string>();
             bigram_templs_ = new List<string>();
             while (ifs.EndOfStream == false)
             {
-                string line = ifs.ReadLine();
+                var line = ifs.ReadLine();
                 if (line.Length == 0 || line[0] == '#')
                 {
                     continue;
@@ -306,16 +307,16 @@ namespace CRFSharp
 
         bool OpenTrainCorpusFile(string strTrainingCorpusFileName)
         {
-            StreamReader ifs = new StreamReader(strTrainingCorpusFileName);
+            var ifs = new StreamReader(strTrainingCorpusFileName);
             y_ = new List<string>();
             trainCorpusList = new List<List<List<string>>>();
-            HashSet<string> hashCand = new HashSet<string>();
-            List<List<string>> recordList = new List<List<string>>();
+            var hashCand = new HashSet<string>();
+            var recordList = new List<List<string>>();
 
-            int last_xsize = -1;
+            var last_xsize = -1;
             while (ifs.EndOfStream == false)
             {
-                string line = ifs.ReadLine();
+                var line = ifs.ReadLine();
                 if (line.Length == 0 || line[0] == ' ' || line[0] == '\t')
                 {
                     //Current record is finished, save it into the list
@@ -327,8 +328,8 @@ namespace CRFSharp
                     continue;
                 }
 
-                string[] items = line.Split('\t');
-                int size = items.Length;
+                var items = line.Split('\t');
+                var size = items.Length;
                 if (last_xsize >= 0 && last_xsize != size)
                 {
                     return false;
@@ -353,36 +354,38 @@ namespace CRFSharp
         //If feature string is not existed in the set, generate a new id and return it
         public bool BuildFeatures(EncoderTagger tagger)
         {
-            List<long> feature = new List<long>();
+            var feature = new List<long>();
 
             //tagger.feature_id_ = tagger.feature_cache_.Count;
-            for (int cur = 0; cur < tagger.word_num; ++cur)
+            for (var cur = 0; cur < tagger.word_num; ++cur)
             {
-                foreach (string it in unigram_templs_)
+                for (int index = 0; index < unigram_templs_.Count; index++)
                 {
-                    string strFeature = apply_rule(it, cur, tagger);
+                    var it = unigram_templs_[index];
+                    var strFeature = apply_rule(it, cur, tagger);
                     if (strFeature == "")
                     {
                         Console.WriteLine(" format error: " + it);
                     }
 
-                    long id = featureLexicalDict.GetOrAddId(strFeature);
+                    var id = featureLexicalDict.GetOrAddId(strFeature);
                     feature.Add(id);
                 }
                 tagger.feature_cache_.Add(feature.ToArray());
                 feature.Clear();
             }
 
-            for (int cur = 1; cur < tagger.word_num; ++cur)
+            for (var cur = 1; cur < tagger.word_num; ++cur)
             {
-                foreach (string it in bigram_templs_)
+                for (int index = 0; index < bigram_templs_.Count; index++)
                 {
-                    string strFeature = apply_rule(it, cur, tagger);
+                    var it = bigram_templs_[index];
+                    var strFeature = apply_rule(it, cur, tagger);
                     if (strFeature == "")
                     {
                         Console.WriteLine(" format error: " + it);
                     }
-                    long id = featureLexicalDict.GetOrAddId(strFeature);
+                    var id = featureLexicalDict.GetOrAddId(strFeature);
                     feature.Add(id);
                 }
 

--- a/Core/CRFSharp/encoder/OrderableListPartitioner.cs
+++ b/Core/CRFSharp/encoder/OrderableListPartitioner.cs
@@ -40,7 +40,7 @@ namespace CRFSharp
             var partitions =
                 new IEnumerator<KeyValuePair<long, TSource>>[partitionCount];
 
-            for (int i = 0; i < partitionCount; i++)
+            for (var i = 0; i < partitionCount; i++)
             {
                 partitions[i] = dynamicPartitions.GetEnumerator();
             }
@@ -70,7 +70,7 @@ namespace CRFSharp
                 {
                     // Each task gets the next item in the list. The index is 
                     // incremented in a thread-safe manner to avoid races.
-                    int elemIndex = Interlocked.Increment(ref m_pos) - 1;
+                    var elemIndex = Interlocked.Increment(ref m_pos) - 1;
 
                     if (elemIndex >= m_input.Count)
                     {

--- a/Core/CRFSharpWrapper/Decoder.cs
+++ b/Core/CRFSharpWrapper/Decoder.cs
@@ -28,7 +28,7 @@ namespace CRFSharpWrapper
             {
                 return null;
             }
-            SegDecoderTagger tagger = new SegDecoderTagger(nbest, this_crf_max_word_num);
+            var tagger = new SegDecoderTagger(nbest, this_crf_max_word_num);
             tagger.init_by_model(modelReader);
 
             return tagger;
@@ -40,7 +40,7 @@ namespace CRFSharpWrapper
             List<List<string>> inbuf //feature set for segment
             )
         {
-            int ret = 0;
+            var ret = 0;
             if (inbuf.Count == 0)
             {
                 //Empty input string
@@ -84,7 +84,7 @@ namespace CRFSharpWrapper
             List<List<string>> inbuf //feature set for segment
             )
         {
-            int ret = 0;
+            var ret = 0;
             if (inbuf.Count == 0)
             {
                 //Empty input string

--- a/Core/CRFSharpWrapper/Encoder.cs
+++ b/Core/CRFSharpWrapper/Encoder.cs
@@ -171,7 +171,7 @@ namespace CRFSharpWrapper
                 var threadList = new List<Thread>();
                 for (var i = 0; i < args.threads_num; i++)
                 {
-                    var thread = new Thread(new ThreadStart(processList[i].Run));
+                    var thread = new Thread(processList[i].Run);
                     thread.Start();
                     threadList.Add(thread);
                 }

--- a/Core/CRFSharpWrapper/SegDecoderTagger.cs
+++ b/Core/CRFSharpWrapper/SegDecoderTagger.cs
@@ -24,20 +24,20 @@ namespace CRFSharpWrapper
             term_buf.Clear();
 
             //build raw result at first
-            int iRet = termbuf_build(term_buf);
+            var iRet = termbuf_build(term_buf);
             if (iRet != Utils.ERROR_SUCCESS)
             {
                 return iRet;
             }
 
             //Then build token result
-            int term_len = 0;
-            double weight = 0.0;
-            int num = 0;
-            for (int i = 0; i < x_.Count; i++)
+            var term_len = 0;
+            var weight = 0.0;
+            var num = 0;
+            for (var i = 0; i < x_.Count; i++)
             {
                 //Adding the length of current token
-                string strTag = term_buf.result_[i];
+                var strTag = term_buf.result_[i];
                 term_len += x_[i][0].Length;
                 weight += term_buf.weight_[i];
                 num++;
@@ -47,11 +47,11 @@ namespace CRFSharpWrapper
                     strTag.StartsWith("M_") == false) ||
                     i == x_.Count - 1)
                 {
-                    SegToken tkn = new SegToken();
+                    var tkn = new SegToken();
                     tkn.length = term_len;
                     tkn.offset = term_buf.termTotalLength;
 
-                    int spos = strTag.IndexOf('_');
+                    var spos = strTag.IndexOf('_');
                     if (spos < 0)
                     {
                         if (strTag == "NOR")
@@ -94,8 +94,8 @@ namespace CRFSharpWrapper
 
         public int output(crf_seg_out[] pout)
         {
-            int n = 0;
-            int ret = 0;
+            var n = 0;
+            var ret = 0;
 
             if (nbest_ == 1)
             {
@@ -109,7 +109,7 @@ namespace CRFSharpWrapper
             else
             {
                 //Fill the n best result
-                int iNBest = nbest_;
+                var iNBest = nbest_;
                 if (pout.Length < iNBest)
                 {
                     iNBest = pout.Length;

--- a/Core/CRFSharpWrapper/Shrink.cs
+++ b/Core/CRFSharpWrapper/Shrink.cs
@@ -11,12 +11,12 @@ namespace CRFSharpWrapper
     {
         public void Process(string strModelFileName, string strShrinkedModelFileName, int thread_num_ = 1)
         {
-            StreamReader sr = new StreamReader(strModelFileName);
+            var sr = new StreamReader(strModelFileName);
             string strLine;
 
             //读入版本号
             strLine = sr.ReadLine();
-            uint version = uint.Parse(strLine.Split(':')[1].Trim());
+            var version = uint.Parse(strLine.Split(':')[1].Trim());
             if (version == CRFSharp.Utils.MODEL_TYPE_SHRINKED)
             {
                 Console.WriteLine("The input model has been shrinked");
@@ -25,21 +25,21 @@ namespace CRFSharpWrapper
 
             //读入cost_factor
             strLine = sr.ReadLine();
-            double cost_factor_ = double.Parse(strLine.Split(':')[1].Trim());
+            var cost_factor_ = double.Parse(strLine.Split(':')[1].Trim());
 
             //读入maxid
             strLine = sr.ReadLine();
-            long maxid_ = long.Parse(strLine.Split(':')[1].Trim());
+            var maxid_ = long.Parse(strLine.Split(':')[1].Trim());
 
             //读入xsize
             strLine = sr.ReadLine();
-            uint xsize_ = uint.Parse(strLine.Split(':')[1].Trim());
+            var xsize_ = uint.Parse(strLine.Split(':')[1].Trim());
 
             //读入空行
             strLine = sr.ReadLine();
 
             //读入待标注的标签
-            List<string> y_ = new List<string>();
+            var y_ = new List<string>();
             while (true)
             {
                 strLine = sr.ReadLine();
@@ -51,8 +51,8 @@ namespace CRFSharpWrapper
             }
 
             //读入unigram和bigram模板
-            List<string> unigram_templs_ = new List<string>();
-            List<string> bigram_templs_ = new List<string>();
+            var unigram_templs_ = new List<string>();
+            var bigram_templs_ = new List<string>();
             while (sr.EndOfStream == false)
             {
                 strLine = sr.ReadLine();
@@ -73,17 +73,17 @@ namespace CRFSharpWrapper
 
 
             //Load all features alpha data
-            string filename_alpha = strModelFileName + ".alpha";
-            string filename_shrink_alpha = strShrinkedModelFileName + ".alpha";
-            StreamReader sr_alpha = new StreamReader(filename_alpha);
-            BinaryReader br_alpha = new BinaryReader(sr_alpha.BaseStream);
+            var filename_alpha = strModelFileName + ".alpha";
+            var filename_shrink_alpha = strShrinkedModelFileName + ".alpha";
+            var sr_alpha = new StreamReader(filename_alpha);
+            var br_alpha = new BinaryReader(sr_alpha.BaseStream);
 
-            StreamWriter sw_alpha = new StreamWriter(filename_shrink_alpha);
-            BinaryWriter bw_alpha = new BinaryWriter(sw_alpha.BaseStream);
+            var sw_alpha = new StreamWriter(filename_shrink_alpha);
+            var bw_alpha = new BinaryWriter(sw_alpha.BaseStream);
             long shrinked_alpha_size = 0;
 
             //Only reserve non-zero feature weights and save them into file as two-tuples format
-            FixedBigArray<double> alpha_ = new FixedBigArray<double>(maxid_ + 1, 0);
+            var alpha_ = new FixedBigArray<double>(maxid_ + 1, 0);
             for (long i = 0; i < maxid_; i++)
             {
                 alpha_[i] = br_alpha.ReadSingle();
@@ -99,20 +99,20 @@ namespace CRFSharpWrapper
             bw_alpha.Close();
 
             //Only reserved lexical feature whose weights is non-zero
-            VarBigArray<int> varValue = new VarBigArray<int>(1024);
-            VarBigArray<string> varFeature = new VarBigArray<string>(1024);
-            int feaCnt = 0;
-            string filename_feature = strModelFileName + ".feature.raw_text";
-            StreamReader sr_fea = new StreamReader(filename_feature);
+            var varValue = new VarBigArray<int>(1024);
+            var varFeature = new VarBigArray<string>(1024);
+            var feaCnt = 0;
+            var filename_feature = strModelFileName + ".feature.raw_text";
+            var sr_fea = new StreamReader(filename_feature);
             while (sr_fea.EndOfStream == false)
             {
                 strLine = sr_fea.ReadLine();
-                string[] items = strLine.Split('\t');
-                string strFeature = items[0];
-                int key = int.Parse(items[1]);
-                int size = (strFeature[0] == 'U' ? y_.Count : y_.Count * y_.Count);
-                bool hasAlpha = false;
-                for (int i = key; i < key + size; i++)
+                var items = strLine.Split('\t');
+                var strFeature = items[0];
+                var key = int.Parse(items[1]);
+                var size = (strFeature[0] == 'U' ? y_.Count : y_.Count * y_.Count);
+                var hasAlpha = false;
+                for (var i = key; i < key + size; i++)
                 {
                     if (alpha_[i] != 0)
                     {
@@ -135,16 +135,16 @@ namespace CRFSharpWrapper
             maxid_ = shrinked_alpha_size;
 
             //Build new lexical feature
-            FixedBigArray<int> val = new FixedBigArray<int>(feaCnt, 0);
-            FixedBigArray<string> fea = new FixedBigArray<string>(feaCnt, 0);
-            for (int i = 0; i < feaCnt; i++)
+            var val = new FixedBigArray<int>(feaCnt, 0);
+            var fea = new FixedBigArray<string>(feaCnt, 0);
+            for (var i = 0; i < feaCnt; i++)
             {
                 fea[i] = varFeature[i];
                 val[i] = varValue[i];
             }
             varFeature = null;
             varValue = null;
-            DoubleArrayTrieBuilder da = new DoubleArrayTrieBuilder(thread_num_);
+            var da = new DoubleArrayTrieBuilder(thread_num_);
             if (da.build(fea, val, 0.95) == false)
             {
                 Console.WriteLine("Build lexical dictionary failed.");
@@ -152,7 +152,7 @@ namespace CRFSharpWrapper
             }
             da.save(strShrinkedModelFileName + ".feature");
 
-            StreamWriter tofs = new StreamWriter(strShrinkedModelFileName);
+            var tofs = new StreamWriter(strShrinkedModelFileName);
 
             // header
             tofs.WriteLine("version: " + CRFSharp.Utils.MODEL_TYPE_SHRINKED);
@@ -163,18 +163,18 @@ namespace CRFSharpWrapper
             tofs.WriteLine();
 
             // y
-            for (int i = 0; i < y_.Count; ++i)
+            for (var i = 0; i < y_.Count; ++i)
             {
                 tofs.WriteLine(y_[i]);
             }
             tofs.WriteLine();
 
             // template
-            for (int i = 0; i < unigram_templs_.Count; ++i)
+            for (var i = 0; i < unigram_templs_.Count; ++i)
             {
                 tofs.WriteLine(unigram_templs_[i]);
             }
-            for (int i = 0; i < bigram_templs_.Count; ++i)
+            for (var i = 0; i < bigram_templs_.Count; ++i)
             {
                 tofs.WriteLine(bigram_templs_[i]);
             }

--- a/GenerateFeatureDefault/GenerateFeatureDefault.cs
+++ b/GenerateFeatureDefault/GenerateFeatureDefault.cs
@@ -17,9 +17,10 @@ namespace GenerateFeatureDefault
 
         public List<List<string>> GenerateFeature(string strText)
         {
-            List<List<string>> rstListList = new List<List<string>>();
-            foreach (char ch in strText)
+            var rstListList = new List<List<string>>();
+            for (int index = 0; index < strText.Length; index++)
             {
+                var ch = strText[index];
                 rstListList.Add(new List<string>());
                 rstListList[rstListList.Count - 1].Add(ch.ToString());
             }

--- a/GenerateFeatureDictMatch/GenerateFeatureDictMatch.cs
+++ b/GenerateFeatureDictMatch/GenerateFeatureDictMatch.cs
@@ -21,13 +21,13 @@ namespace GenerateFeatureDictMatch
 
         private Dictionary<string, string> LoadConfigFile(string strFileName)
         {
-            Dictionary<string, string> dict = new Dictionary<string,string>();
+            var dict = new Dictionary<string,string>();
 
-            StreamReader sr = new StreamReader(strFileName);
+            var sr = new StreamReader(strFileName);
             while (sr.EndOfStream == false)
             {
-                string strLine = sr.ReadLine();
-                string [] items = strLine.Split('=');
+                var strLine = sr.ReadLine();
+                var items = strLine.Split('=');
 
                 items[0] = items[0].ToLower().Trim();
                 items[1] = items[1].ToLower().Trim();
@@ -63,8 +63,8 @@ namespace GenerateFeatureDictMatch
                 return false;
             }
 
-            string strDictMatchFileName = configDict[KEY_LEXICAL_DICT_FILE_NAME.ToLower()];
-            bool bBinaryDict = bool.Parse(configDict[KEY_BINARY_DICT_TYPE.ToLower()]);
+            var strDictMatchFileName = configDict[KEY_LEXICAL_DICT_FILE_NAME.ToLower()];
+            var bBinaryDict = bool.Parse(configDict[KEY_BINARY_DICT_TYPE.ToLower()]);
 
             if (strDictMatchFileName.Length == 0)
             {
@@ -84,7 +84,7 @@ namespace GenerateFeatureDictMatch
 
         public List<List<string>> GenerateFeature(string strText)
         {
-            List<List<string>> rstListList = new List<List<string>>();
+            var rstListList = new List<List<string>>();
             if (dictmatch == null)
             {
                 return rstListList;
@@ -97,18 +97,18 @@ namespace GenerateFeatureDictMatch
             string [] astrDictMatch;
             astrDictMatch = new string[strText.Length];
 
-            for (int i = 0; i < dm_r.Count; i++)
+            for (var i = 0; i < dm_r.Count; i++)
             {
-                int offset = dm_offsetList[i];
-                int len = (int)dm_r[i].len;
+                var offset = dm_offsetList[i];
+                var len = (int)dm_r[i].len;
 
-                for (int j = offset; j < offset + len; j++)
+                for (var j = offset; j < offset + len; j++)
                 {
                     astrDictMatch[j] = dm_r[i].strProp;
                 }
             }
 
-            for (int i = 0;i < strText.Length;i++)
+            for (var i = 0;i < strText.Length;i++)
             {
                 rstListList.Add(new List<string>());
                 rstListList[i].Add(strText[i].ToString());

--- a/corpus2tag/Program.cs
+++ b/corpus2tag/Program.cs
@@ -47,7 +47,7 @@ namespace corpus2tag
                 File.Exists(Properties.Settings.Default.FeatureGeneratorDLL) == true)
             {
                 Console.WriteLine("Loading external DLL: {0}", Properties.Settings.Default.FeatureGeneratorDLL);
-                Assembly ass = Assembly.LoadFrom(Properties.Settings.Default.FeatureGeneratorDLL);
+                var ass = Assembly.LoadFrom(Properties.Settings.Default.FeatureGeneratorDLL);
                 if (ass == null)
                 {
                     Console.WriteLine("Load {0} failed.", Properties.Settings.Default.FeatureGeneratorDLL);
@@ -73,20 +73,20 @@ namespace corpus2tag
                 return;
             }
 
-            Dictionary<string, int> mappedTag2num = new Dictionary<string, int>();
-            Dictionary<string, int> orignalTag2num = new Dictionary<string, int>();
+            var mappedTag2num = new Dictionary<string, int>();
+            var orignalTag2num = new Dictionary<string, int>();
 
-            Dictionary<string, string> t2t = new Dictionary<string, string>();
-            StreamReader sr = new StreamReader(args[0]);
-            StreamWriter sw = new StreamWriter(args[0] + ".tag");
-            StreamWriter sw_f = new StreamWriter(args[0] + ".filtered");
-            StreamReader swmap = new StreamReader(args[1]);
+            var t2t = new Dictionary<string, string>();
+            var sr = new StreamReader(args[0]);
+            var sw = new StreamWriter(args[0] + ".tag");
+            var sw_f = new StreamWriter(args[0] + ".filtered");
+            var swmap = new StreamReader(args[1]);
 
             //Load tag mapping file
             while (swmap.EndOfStream == false)
             {
-                string strLine = swmap.ReadLine().Trim();
-                string [] items = strLine.Split(new char[]{'\t'});
+                var strLine = swmap.ReadLine().Trim();
+                var items = strLine.Split(new char[]{'\t'});
 
                 if (items.Length != 2)
                 {
@@ -106,27 +106,28 @@ namespace corpus2tag
             swmap.Close();
 
             //Read each line and convert it into CRFSharp training format
-            int LineNo = 0;
+            var LineNo = 0;
             while (sr.EndOfStream == false)
             {
-                string strLine = sr.ReadLine().Trim();
+                var strLine = sr.ReadLine().Trim();
                 LineNo++;
 
                 try
                 {
-                    string strFilterLine = "";
+                    var strFilterLine = "";
                     if (strLine.Length == 0)
                     {
                         continue;
                     }
 
                     //Split the record into token list
-                    string[] items = strLine.Split();
-                    List<List<string>> tagListList = new List<List<string>>();
+                    var items = strLine.Split();
+                    var tagListList = new List<List<string>>();
 
-                    foreach (string item in items)
+                    for (var index = 0; index < items.Length; index++)
                     {
-                        //Check whether the data format is correct
+                        var item = items[index];
+//Check whether the data format is correct
                         if (item[item.Length - 1] != ']')
                         {
                             Console.WriteLine("{0} is invalidated format at Line #{1}", strLine, LineNo);
@@ -134,7 +135,7 @@ namespace corpus2tag
                         }
 
                         string term = "", tag = "";
-                        int pos = item.LastIndexOf('[');
+                        var pos = item.LastIndexOf('[');
                         if (pos >= 0)
                         {
                             term = item.Substring(0, pos).ToLower();
@@ -180,7 +181,7 @@ namespace corpus2tag
                         {
                             tag = "";
                         }
-                        for (int i = 0; i < term.Length; i++)
+                        for (var i = 0; i < term.Length; i++)
                         {
                             string tag2;
 
@@ -224,8 +225,8 @@ namespace corpus2tag
                     sw_f.WriteLine(strFilterLine);
 
 
-                    StringBuilder sb = new StringBuilder();
-                    for (int i = 0; i < tagListList.Count; i++)
+                    var sb = new StringBuilder();
+                    for (var i = 0; i < tagListList.Count; i++)
                     {
                         sb.Append(tagListList[i][0]);
                     }
@@ -237,15 +238,15 @@ namespace corpus2tag
                         Console.WriteLine("Generate Feature invalidated. Error: {0}", strLine);
                     }
 
-                    for (int i = 0; i < tagListList.Count; i++)
+                    for (var i = 0; i < tagListList.Count; i++)
                     {
-                        string strRstLine = tagListList[i][0];
+                        var strRstLine = tagListList[i][0];
                         if (tagListList[i][0] != featureListList[i][0])
                         {
                             Console.WriteLine("Character feature is not equal.");
                         }
 
-                        for (int j = 1; j < featureListList[i].Count; j++)
+                        for (var j = 1; j < featureListList[i].Count; j++)
                         {
                             strRstLine = strRstLine + "\t" + featureListList[i][j];
                         }
@@ -267,13 +268,13 @@ namespace corpus2tag
             }
 
             Console.WriteLine("Orignal Tags Statistics:");
-            foreach (KeyValuePair<string, int> pair in orignalTag2num)
+            foreach (var pair in orignalTag2num)
             {
                 Console.WriteLine("{0}\t{1}", pair.Key, pair.Value);
             }
 
             Console.WriteLine("Mapped Tag Statistics:");
-            foreach (KeyValuePair<string, int> pair in mappedTag2num)
+            foreach (var pair in mappedTag2num)
             {
                 Console.WriteLine("{0}\t{1}", pair.Key, pair.Value);
             }


### PR DESCRIPTION
According to profiling results lots of CPU resources are wasted during enumeration. Iterating through big collections using foreach is a bit slower than using for (runtime checks that collection was not modified , etc) that is why I replaced all usages of foreach with for. 

I like your library, and in our company we currently use it in a test mode. But  in the nearest future it could be deployed in production. That is why I am willing to work out some performance issues, for ex. use CUDAfy for some calculations using GPU (OpenCL or CUDA)
